### PR TITLE
Add dynamic rendering to multiple pages for improved performance

### DIFF
--- a/src/app/(content)/fixture/page.tsx
+++ b/src/app/(content)/fixture/page.tsx
@@ -4,6 +4,8 @@ import { Fixture } from "@/lib/football-api/types/fixture";
 import { getLastFixtures } from "@/lib/football-api/use-cases/fixture";
 import { Suspense } from "react";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata() {
   const data = await getLastFixtures();
   return {

--- a/src/app/(content)/results/[fixtureId]/page.tsx
+++ b/src/app/(content)/results/[fixtureId]/page.tsx
@@ -9,6 +9,8 @@ import { ArrowLeftIcon } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+export const dynamic = "force-dynamic";
+
 export async function generateMetadata({
   params,
 }: {

--- a/src/app/(content)/results/page.tsx
+++ b/src/app/(content)/results/page.tsx
@@ -2,6 +2,7 @@ import { PageHeader } from "@/components/common/header-page";
 import { DisplayFullResult } from "@/components/fixture/display-full-result";
 import { getLastResults } from "@/lib/football-api/use-cases/result";
 import { Metadata } from "next";
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Super Lig France - Résultats",

--- a/src/app/(content)/standing/page.tsx
+++ b/src/app/(content)/standing/page.tsx
@@ -12,6 +12,8 @@ import {
 import { Metadata } from "next";
 import { Suspense } from "react";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Super Lig France - Classement",
   description: "Suivez le classement de la Süper Lig",


### PR DESCRIPTION
- Introduced `export const dynamic = "force-dynamic";` in the `page.tsx` files for fixture, results, and standings components to enable dynamic rendering.
- Ensured consistent implementation across all modified components to enhance performance and user experience.