### PR TITLE
Fix logic in getLastResults to prevent incorrect round retrieval

### DIFF
--- a/src/lib/football-api/use-cases/result.ts
+++ b/src/lib/football-api/use-cases/result.ts
@@ -26,10 +26,12 @@ export const getLastResults = async () => {
   if (allRounds) {
     currentRound = allRounds.find((round) => round.is_current === true);
     if (currentRound) {
-      const intRound = parseInt(currentRound?.name || "0");
-      currentRound = allRounds.find(
-        (round) => parseInt(round.name) === intRound - 1
-      );
+      if (!currentRound.finished === true) {
+        const intRound = parseInt(currentRound?.name || "0");
+        currentRound = allRounds.find(
+          (round) => parseInt(round.name) === intRound - 1
+        );
+      }
     }
     const currentRoundName = currentRound?.name || "";
     const startingDate = currentRound?.starting_at || "";


### PR DESCRIPTION
- Updated the condition to check if the current round is not finished before attempting to retrieve the previous round.
- Ensured that the logic correctly handles the retrieval of rounds based on their current status, improving the accuracy of results fetching.